### PR TITLE
fix: Honor `nullable` when it sits beside a composition keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `nullable: true` is now honoured when it sits beside a composition keyword
+  instead of only on the branch schemas, so the standard OAS 3.0 workaround
+  for a nullable `$ref` — `{allOf: [$ref], nullable: true}` — accepts `null`.
+  `AllOfValidator`, `AnyOfValidator`, `OneOfValidator`,
+  `OneOfValidatorWithContext` and `IfThenElseValidator` short-circuit when the
+  schema carrying the keyword is nullable, rather than dispatching `null` into
+  branches that reject it. `anyOf`/`oneOf` treat this as the keyword being
+  satisfied, not as a matching branch, so `oneOf` still enforces exactly-one
+  for non-null data. A `null` member of an OAS 3.1 `type` union is ordinary
+  JSON Schema and keeps composing — only `nullable: true` waives branches, and
+  only while `nullableAsType` is enabled (#50).
+
 ## [0.7.0]
 
 Preparation for the 1.0.0 stable release. This section tracks work that

--- a/src/Validator/Schema/OneOfValidatorWithContext.php
+++ b/src/Validator/Schema/OneOfValidatorWithContext.php
@@ -47,6 +47,10 @@ final readonly class OneOfValidatorWithContext
             return;
         }
 
+        if (null === $data && SchemaValueNormalizer::isNullableSchema($schema, $context->nullableAsType)) {
+            return;
+        }
+
         if ($useDiscriminator && null !== $schema->discriminator) {
             $this->validateWithDiscriminator($data, $schema, $context);
             return;

--- a/src/Validator/Schema/SchemaValueNormalizer.php
+++ b/src/Validator/Schema/SchemaValueNormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Duyler\OpenApi\Validator\Schema;
 
+use Duyler\OpenApi\Schema\Model\Schema;
 use Duyler\OpenApi\Validator\Exception\InvalidDataTypeException;
 use stdClass;
 
@@ -48,6 +49,11 @@ final readonly class SchemaValueNormalizer
             'Data must be array, int, string, float or bool, %s given',
             $typeDescription,
         ));
+    }
+
+    public static function isNullableSchema(Schema $schema, bool $nullableAsType): bool
+    {
+        return $nullableAsType && $schema->nullable;
     }
 
     /**

--- a/src/Validator/SchemaValidator/AbstractSchemaValidator.php
+++ b/src/Validator/SchemaValidator/AbstractSchemaValidator.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Duyler\OpenApi\Validator\SchemaValidator;
 
+use Duyler\OpenApi\Schema\Model\Schema;
 use Duyler\OpenApi\Validator\Error\ValidationContext;
 use Duyler\OpenApi\Validator\PregExecutor;
 use Duyler\OpenApi\Validator\Schema\RegexValidator;
+use Duyler\OpenApi\Validator\Schema\SchemaValueNormalizer;
 use Duyler\OpenApi\Validator\ValidatorPool;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
@@ -19,6 +21,12 @@ abstract readonly class AbstractSchemaValidator implements SchemaValidatorInterf
     public function __construct(
         protected readonly ValidatorDependencies $dependencies,
     ) {}
+
+    protected function acceptsNullAsNullable(mixed $data, Schema $schema, ?ValidationContext $context): bool
+    {
+        return null === $data
+            && SchemaValueNormalizer::isNullableSchema($schema, $context?->nullableAsType ?? true);
+    }
 
     protected function getDataPath(?ValidationContext $context): string
     {

--- a/src/Validator/SchemaValidator/AllOfValidator.php
+++ b/src/Validator/SchemaValidator/AllOfValidator.php
@@ -27,6 +27,10 @@ final readonly class AllOfValidator extends AbstractCompositionalValidator imple
             return;
         }
 
+        if ($this->acceptsNullAsNullable($data, $schema, $context)) {
+            return;
+        }
+
         $result = $this->validateSchemas($schema->allOf, $data, $context, 'allOf');
 
         if ([] !== $result->errors || [] !== $result->abstractErrors) {

--- a/src/Validator/SchemaValidator/AnyOfValidator.php
+++ b/src/Validator/SchemaValidator/AnyOfValidator.php
@@ -24,6 +24,10 @@ final readonly class AnyOfValidator extends AbstractCompositionalValidator imple
             return;
         }
 
+        if ($this->acceptsNullAsNullable($data, $schema, $context)) {
+            return;
+        }
+
         $result = $this->validateSchemas($schema->anyOf, $data, $context, 'anyOf');
 
         if (0 === $result->validCount) {

--- a/src/Validator/SchemaValidator/IfThenElseValidator.php
+++ b/src/Validator/SchemaValidator/IfThenElseValidator.php
@@ -32,6 +32,10 @@ final readonly class IfThenElseValidator extends AbstractSchemaValidator impleme
             return;
         }
 
+        if ($this->acceptsNullAsNullable($data, $schema, $context)) {
+            return;
+        }
+
         if (is_bool($schema->if)) {
             $this->routeThenOrElse(schema: $schema, data: $data, context: $context, ifValid: $schema->if);
 

--- a/src/Validator/SchemaValidator/OneOfValidator.php
+++ b/src/Validator/SchemaValidator/OneOfValidator.php
@@ -25,6 +25,10 @@ final readonly class OneOfValidator extends AbstractCompositionalValidator imple
             return;
         }
 
+        if ($this->acceptsNullAsNullable($data, $schema, $context)) {
+            return;
+        }
+
         $result = $this->validateSchemas($schema->oneOf, $data, $context, 'oneOf');
 
         if (0 === $result->validCount) {

--- a/src/Validator/SchemaValidator/TypeValidator.php
+++ b/src/Validator/SchemaValidator/TypeValidator.php
@@ -8,6 +8,7 @@ use Duyler\OpenApi\Schema\Model\Schema;
 use Duyler\OpenApi\Validator\EmptyArrayStrategy;
 use Duyler\OpenApi\Validator\Error\ValidationContext;
 use Duyler\OpenApi\Validator\Exception\TypeMismatchError;
+use Duyler\OpenApi\Validator\Schema\SchemaValueNormalizer;
 use Duyler\OpenApi\Validator\TypeFormatter;
 use Override;
 
@@ -41,7 +42,7 @@ final readonly class TypeValidator extends AbstractSchemaValidator implements Ke
 
         $nullableAsType = $context?->nullableAsType ?? true;
 
-        if (null === $data && $schema->nullable && $nullableAsType) {
+        if (null === $data && SchemaValueNormalizer::isNullableSchema($schema, $nullableAsType)) {
             return;
         }
 

--- a/tests/Functional/Response/NullableCompositionTest.php
+++ b/tests/Functional/Response/NullableCompositionTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duyler\OpenApi\Test\Functional\Response;
+
+use Duyler\OpenApi\Builder\OpenApiValidatorBuilder;
+use Duyler\OpenApi\Validator\Exception\ValidationException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression coverage for a JSON:API-shaped OAS 3.0 document where the nullable relationship is
+ * expressed as `allOf: [$ref]` plus `nullable: true`, reached through a nested `properties` chain.
+ *
+ * @see https://github.com/duyler/openapi/issues/50
+ *
+ * @internal
+ */
+final class NullableCompositionTest extends TestCase
+{
+    private const string SPEC = <<<'YAML'
+        openapi: 3.0.0
+        info:
+          title: nullable allOf repro
+          version: 1.0.0
+        paths:
+          '/actions/{actionId}':
+            get:
+              parameters:
+                - name: actionId
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+              responses:
+                '200':
+                  description: One action
+                  content:
+                    application/json:
+                      schema:
+                        type: object
+                        properties:
+                          data:
+                            $ref: '#/components/schemas/Action'
+        components:
+          schemas:
+            FormIdentifier:
+              type: object
+              required: [type, id]
+              properties:
+                type:
+                  type: string
+                  enum: [forms]
+                id:
+                  type: string
+            Action:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum: [actions]
+                id:
+                  type: string
+                relationships:
+                  type: object
+                  properties:
+                    form:
+                      type: object
+                      properties:
+                        data:
+                          allOf:
+                            - $ref: '#/components/schemas/FormIdentifier'
+                          nullable: true
+        YAML;
+
+    private Psr17Factory $psrFactory;
+
+    protected function setUp(): void
+    {
+        $this->psrFactory = new Psr17Factory();
+    }
+
+    #[Test]
+    public function null_relationship_is_accepted_through_nested_properties(): void
+    {
+        $this->validateResponseBody(
+            '{"data":{"type":"actions","id":"1","relationships":{"form":{"data":null}}}}',
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function populated_relationship_is_accepted_through_nested_properties(): void
+    {
+        $this->validateResponseBody(
+            '{"data":{"type":"actions","id":"1","relationships":{"form":{"data":{"type":"forms","id":"7"}}}}}',
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function invalid_relationship_is_still_rejected_through_nested_properties(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->validateResponseBody(
+            '{"data":{"type":"actions","id":"1","relationships":{"form":{"data":{"type":"widgets"}}}}}',
+        );
+    }
+
+    private function validateResponseBody(string $body): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::SPEC)
+            ->build();
+
+        $operation = $validator->validateRequest(
+            $this->psrFactory->createServerRequest('GET', '/actions/1'),
+        );
+
+        $response = $this->psrFactory->createResponse(200)
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($this->psrFactory->createStream($body));
+
+        $validator->validateResponse($response, $operation);
+    }
+}

--- a/tests/Unit/Validator/SchemaValidator/AllOfValidatorTest.php
+++ b/tests/Unit/Validator/SchemaValidator/AllOfValidatorTest.php
@@ -8,6 +8,7 @@ use Duyler\OpenApi\Validator\SchemaValidator\AllOfValidator;
 use Duyler\OpenApi\Validator\SchemaValidator\ValidatorDependencies;
 
 use Duyler\OpenApi\Schema\Model\Schema;
+use Duyler\OpenApi\Validator\Error\ValidationContext;
 use Duyler\OpenApi\Validator\Exception\ValidationException;
 use Duyler\OpenApi\Validator\ValidatorPool;
 use Duyler\OpenApi\Validator\Format\BuiltinFormats;
@@ -236,5 +237,33 @@ class AllOfValidatorTest extends TestCase
             $errors = $e->getErrors();
             self::assertGreaterThan(0, count($errors));
         }
+    }
+
+    #[Test]
+    public function allOf_passes_when_parent_schema_is_nullable_and_data_is_null(): void
+    {
+        $schema = new Schema(
+            nullable: true,
+            allOf: [new Schema(type: 'object', required: ['id'])],
+        );
+
+        $this->validator->validate(null, $schema);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function allOf_rejects_null_when_parent_nullable_is_not_honored(): void
+    {
+        $schema = new Schema(
+            nullable: true,
+            allOf: [new Schema(type: 'object', required: ['id'])],
+        );
+
+        $context = ValidationContext::create($this->pool, nullableAsType: false);
+
+        $this->expectException(ValidationException::class);
+
+        $this->validator->validate(null, $schema, $context);
     }
 }

--- a/tests/Unit/Validator/SchemaValidator/AnyOfValidatorTest.php
+++ b/tests/Unit/Validator/SchemaValidator/AnyOfValidatorTest.php
@@ -239,4 +239,32 @@ class AnyOfValidatorTest extends TestCase
 
         $this->expectNotToPerformAssertions();
     }
+
+    #[Test]
+    public function anyOf_passes_when_parent_schema_is_nullable_and_data_is_null(): void
+    {
+        $schema = new Schema(
+            nullable: true,
+            anyOf: [new Schema(type: 'object', required: ['id'])],
+        );
+
+        $this->validator->validate(null, $schema);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function anyOf_rejects_null_when_parent_nullable_is_not_honored(): void
+    {
+        $schema = new Schema(
+            nullable: true,
+            anyOf: [new Schema(type: 'object', required: ['id'])],
+        );
+
+        $context = ValidationContext::create($this->pool, nullableAsType: false);
+
+        $this->expectException(ValidationException::class);
+
+        $this->validator->validate(null, $schema, $context);
+    }
 }

--- a/tests/Unit/Validator/SchemaValidator/IfThenElseValidatorTest.php
+++ b/tests/Unit/Validator/SchemaValidator/IfThenElseValidatorTest.php
@@ -8,6 +8,8 @@ use Duyler\OpenApi\Validator\SchemaValidator\IfThenElseValidator;
 use Duyler\OpenApi\Validator\SchemaValidator\ValidatorDependencies;
 
 use Duyler\OpenApi\Schema\Model\Schema;
+use Duyler\OpenApi\Validator\Error\ValidationContext;
+use Duyler\OpenApi\Validator\Exception\InvalidDataTypeException;
 use Duyler\OpenApi\Validator\Exception\MaximumError;
 use Duyler\OpenApi\Validator\ValidatorPool;
 use Duyler\OpenApi\Validator\Format\BuiltinFormats;
@@ -155,5 +157,35 @@ class IfThenElseValidatorTest extends TestCase
         $this->validator->validate(5, $schema);
 
         $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function skip_branches_when_parent_schema_is_nullable_and_data_is_null(): void
+    {
+        $schema = new Schema(
+            nullable: true,
+            if: new Schema(type: 'string'),
+            else: new Schema(type: 'object', required: ['id']),
+        );
+
+        $this->validator->validate(null, $schema);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function apply_branches_to_null_when_parent_nullable_is_not_honored(): void
+    {
+        $schema = new Schema(
+            nullable: true,
+            if: new Schema(type: 'string'),
+            else: new Schema(type: 'object', required: ['id']),
+        );
+
+        $context = ValidationContext::create($this->pool, nullableAsType: false);
+
+        $this->expectException(InvalidDataTypeException::class);
+
+        $this->validator->validate(null, $schema, $context);
     }
 }

--- a/tests/Unit/Validator/SchemaValidator/NullableCompositionTest.php
+++ b/tests/Unit/Validator/SchemaValidator/NullableCompositionTest.php
@@ -1,0 +1,375 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duyler\OpenApi\Test\Unit\Validator\SchemaValidator;
+
+use Duyler\OpenApi\Builder\OpenApiValidatorBuilder;
+use Duyler\OpenApi\Builder\OpenApiValidatorInterface;
+use Duyler\OpenApi\Validator\Exception\ValidationException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * OAS 3.0 has no way to attach `nullable` to a `$ref`, so the documented workaround is to
+ * wrap the reference in a single-branch composition and put `nullable: true` beside it.
+ * The keyword sits on the parent, not on the branch, and must be honored there.
+ *
+ * @internal
+ */
+final class NullableCompositionTest extends TestCase
+{
+    private const string SPEC = <<<'YAML'
+        openapi: 3.0.3
+        info:
+          title: Nullable composition
+          version: 1.0.0
+        components:
+          schemas:
+            FormIdentifier:
+              type: object
+              required: [type, id]
+              properties:
+                type:
+                  enum: [forms]
+                id:
+                  type: string
+            AllOfNullable:
+              allOf:
+                - $ref: '#/components/schemas/FormIdentifier'
+              nullable: true
+            TypedAllOfNullable:
+              type: object
+              allOf:
+                - $ref: '#/components/schemas/FormIdentifier'
+              nullable: true
+            AnyOfNullable:
+              anyOf:
+                - $ref: '#/components/schemas/FormIdentifier'
+              nullable: true
+            OneOfNullable:
+              oneOf:
+                - $ref: '#/components/schemas/FormIdentifier'
+              nullable: true
+            AllOfNotNullable:
+              allOf:
+                - $ref: '#/components/schemas/FormIdentifier'
+            AllOfBranchNullable:
+              allOf:
+                - type: object
+                  nullable: true
+                  required: [type, id]
+                  properties:
+                    type:
+                      enum: [forms]
+                    id:
+                      type: string
+            PlainNullable:
+              type: object
+              nullable: true
+              required: [type, id]
+              properties:
+                type:
+                  enum: [forms]
+                id:
+                  type: string
+        YAML;
+
+    private const string SPEC_31 = <<<'YAML'
+        openapi: 3.1.0
+        info:
+          title: Nullable composition 3.1
+          version: 1.0.0
+        components:
+          schemas:
+            Identifier:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: string
+            UnionOutside:
+              type: ['object', 'null']
+              required: [id]
+              properties:
+                id:
+                  type: string
+            UnionOnBranch:
+              allOf:
+                - type: ['object', 'null']
+                  required: [id]
+                  properties:
+                    id:
+                      type: string
+            UnionOnParent:
+              type: ['object', 'null']
+              allOf:
+                - $ref: '#/components/schemas/Identifier'
+            NullableOnParent:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/Identifier'
+        YAML;
+
+    private const string SPEC_IN_PLACE = <<<'YAML'
+        openapi: 3.0.3
+        info:
+          title: Nullable in-place applicators
+          version: 1.0.0
+        components:
+          schemas:
+            Identifier:
+              type: object
+              required: [id]
+              properties:
+                id:
+                  type: string
+            IfElseNullable:
+              nullable: true
+              if:
+                type: string
+              else:
+                $ref: '#/components/schemas/Identifier'
+            NotNullable:
+              nullable: true
+              not:
+                type: string
+            DependentSchemasNullable:
+              nullable: true
+              dependentSchemas:
+                a:
+                  required: [b]
+        YAML;
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function nullableParentSchemas(): iterable
+    {
+        yield 'allOf + nullable' => ['AllOfNullable'];
+        yield 'type + allOf + nullable' => ['TypedAllOfNullable'];
+        yield 'anyOf + nullable' => ['AnyOfNullable'];
+        yield 'oneOf + nullable' => ['OneOfNullable'];
+        yield 'nullable branch inside allOf' => ['AllOfBranchNullable'];
+        yield 'nullable without composition' => ['PlainNullable'];
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function allSchemas(): iterable
+    {
+        yield from self::nullableParentSchemas();
+        yield 'allOf without nullable' => ['AllOfNotNullable'];
+    }
+
+    #[Test]
+    #[DataProvider('nullableParentSchemas')]
+    public function null_is_accepted_by_nullable_schema(string $schemaName): void
+    {
+        $this->validator()->validateSchema(null, '#/components/schemas/' . $schemaName);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    #[DataProvider('allSchemas')]
+    public function valid_object_is_accepted(string $schemaName): void
+    {
+        $this->validator()->validateSchema(self::validObject(), '#/components/schemas/' . $schemaName);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function null_is_rejected_when_composition_is_not_nullable(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->validator()->validateSchema(null, '#/components/schemas/AllOfNotNullable');
+    }
+
+    #[Test]
+    #[DataProvider('allSchemas')]
+    public function invalid_object_is_still_rejected(string $schemaName): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->validator()->validateSchema(['type' => 'wrong'], '#/components/schemas/' . $schemaName);
+    }
+
+    #[Test]
+    #[DataProvider('nullableParentSchemas')]
+    public function null_is_rejected_when_nullable_as_type_is_disabled(string $schemaName): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->validator(nullableAsType: false)->validateSchema(null, '#/components/schemas/' . $schemaName);
+    }
+
+    #[Test]
+    public function oneOf_still_rejects_data_matching_more_than_one_branch(): void
+    {
+        $yaml = <<<'YAML'
+            openapi: 3.0.3
+            info:
+              title: Nullable oneOf overlap
+              version: 1.0.0
+            components:
+              schemas:
+                Overlapping:
+                  nullable: true
+                  oneOf:
+                    - type: object
+                      required: [id]
+                      properties:
+                        id:
+                          type: string
+                    - type: object
+                      required: [id]
+                      properties:
+                        id:
+                          type: string
+            YAML;
+
+        $validator = OpenApiValidatorBuilder::create()->fromYamlString($yaml)->build();
+
+        $validator->validateSchema(null, '#/components/schemas/Overlapping');
+
+        $this->expectException(ValidationException::class);
+
+        $validator->validateSchema(['id' => '1'], '#/components/schemas/Overlapping');
+    }
+
+    #[Test]
+    public function oas_31_null_type_union_is_honored_inside_and_outside_compositions(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()->fromYamlString(self::SPEC_31)->build();
+
+        foreach (['UnionOutside', 'UnionOnBranch', 'NullableOnParent'] as $schemaName) {
+            $validator->validateSchema(null, '#/components/schemas/' . $schemaName);
+            $validator->validateSchema(['id' => '1'], '#/components/schemas/' . $schemaName);
+        }
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * A `null` member of a `type` union is ordinary JSON Schema and keeps composing: `allOf`
+     * branches still have to match. Only OAS `nullable: true` — which the spec defines as
+     * "allows sending a null value for the defined schema" — waives them.
+     */
+    #[Test]
+    public function oas_31_null_type_union_on_parent_does_not_waive_composition_branches(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()->fromYamlString(self::SPEC_31)->build();
+
+        $validator->validateSchema(['id' => '1'], '#/components/schemas/UnionOnParent');
+
+        $this->expectException(ValidationException::class);
+
+        $validator->validateSchema(null, '#/components/schemas/UnionOnParent');
+    }
+
+    #[Test]
+    public function discriminated_oneOf_with_nullable_parent_accepts_null_and_still_discriminates(): void
+    {
+        $yaml = <<<'YAML'
+            openapi: 3.0.3
+            info:
+              title: Nullable discriminated oneOf
+              version: 1.0.0
+            components:
+              schemas:
+                Cat:
+                  type: object
+                  required: [petType, meows]
+                  properties:
+                    petType:
+                      type: string
+                    meows:
+                      type: boolean
+                Dog:
+                  type: object
+                  required: [petType, barks]
+                  properties:
+                    petType:
+                      type: string
+                    barks:
+                      type: boolean
+                Pet:
+                  nullable: true
+                  discriminator:
+                    propertyName: petType
+                    mapping:
+                      cat: '#/components/schemas/Cat'
+                      dog: '#/components/schemas/Dog'
+                  oneOf:
+                    - $ref: '#/components/schemas/Cat'
+                    - $ref: '#/components/schemas/Dog'
+            YAML;
+
+        $validator = OpenApiValidatorBuilder::create()->fromYamlString($yaml)->build();
+
+        $validator->validateSchema(null, '#/components/schemas/Pet');
+        $validator->validateSchema(['petType' => 'cat', 'meows' => true], '#/components/schemas/Pet');
+
+        $this->expectException(ValidationException::class);
+
+        $validator->validateSchema(['petType' => 'cat', 'barks' => true], '#/components/schemas/Pet');
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function inPlaceApplicators(): iterable
+    {
+        yield 'if/else' => ['IfElseNullable'];
+        yield 'not' => ['NotNullable'];
+        yield 'dependentSchemas' => ['DependentSchemasNullable'];
+    }
+
+    #[Test]
+    #[DataProvider('inPlaceApplicators')]
+    public function nullable_parent_accepts_null_for_other_in_place_applicators(string $schemaName): void
+    {
+        $validator = OpenApiValidatorBuilder::create()->fromYamlString(self::SPEC_IN_PLACE)->build();
+
+        $validator->validateSchema(null, '#/components/schemas/' . $schemaName);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function nullable_parent_does_not_stop_if_else_from_routing_non_null_data(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()->fromYamlString(self::SPEC_IN_PLACE)->build();
+
+        $validator->validateSchema('a string', '#/components/schemas/IfElseNullable');
+        $validator->validateSchema(['id' => '1'], '#/components/schemas/IfElseNullable');
+
+        $this->expectException(ValidationException::class);
+
+        $validator->validateSchema(['id' => 1], '#/components/schemas/IfElseNullable');
+    }
+
+    /**
+     * @return array{type: string, id: string}
+     */
+    private static function validObject(): array
+    {
+        return ['type' => 'forms', 'id' => '1'];
+    }
+
+    private function validator(bool $nullableAsType = true): OpenApiValidatorInterface
+    {
+        $builder = OpenApiValidatorBuilder::create()->fromYamlString(self::SPEC);
+
+        $builder = $nullableAsType
+            ? $builder->enableNullableAsType()
+            : $builder->disableNullableAsType();
+
+        return $builder->build();
+    }
+}

--- a/tests/Unit/Validator/SchemaValidator/OneOfValidatorTest.php
+++ b/tests/Unit/Validator/SchemaValidator/OneOfValidatorTest.php
@@ -270,4 +270,35 @@ class OneOfValidatorTest extends TestCase
 
         $this->expectNotToPerformAssertions();
     }
+
+    #[Test]
+    public function oneOf_passes_when_parent_schema_is_nullable_and_data_is_null(): void
+    {
+        $schema = new Schema(
+            nullable: true,
+            oneOf: [
+                new Schema(type: 'object', required: ['id']),
+                new Schema(type: 'object', required: ['name']),
+            ],
+        );
+
+        $this->validator->validate(null, $schema);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function oneOf_rejects_null_when_parent_nullable_is_not_honored(): void
+    {
+        $schema = new Schema(
+            nullable: true,
+            oneOf: [new Schema(type: 'object', required: ['id'])],
+        );
+
+        $context = ValidationContext::create($this->pool, nullableAsType: false);
+
+        $this->expectException(ValidationException::class);
+
+        $this->validator->validate(null, $schema, $context);
+    }
 }


### PR DESCRIPTION
Closes #50.

## The bug

In OAS 3.0 a `$ref` cannot have siblings, so the documented way to make a referenced schema nullable is to wrap it:

```yaml
data:
  allOf:
    - $ref: '#/components/schemas/FormIdentifier'
  nullable: true
```

`null` was rejected. `TypeValidator::validate()` honors `nullable` on the schema being validated, but `AbstractCompositionalValidator::normalizeForBranch()` consulted `$subSchema->nullable` — the nullability of each *branch* — and never saw the parent that carries the keyword. `AllOfValidator`, `AnyOfValidator` and `OneOfValidator` therefore dispatched `null` into every branch, where it failed. `OneOfValidatorWithContext::hasNullableSchema()` made the same branch-only assumption on the context-carrying path, so both validator families were affected. Adding `type: object` beside the composition keyword did not help — `TypeValidator`'s early return only skips its own keyword.

## Before / after

The issue's repro script, unchanged:

```
BEFORE  FAIL: All of the schemas must match, but 1 failed
              getErrors() returned 0 error(s)

AFTER   PASS: null relationship accepted
```

Full matrix via `validateSchema()`, same branch schema `B` = `{type: object, required: [type, id], properties: {type: {enum: [forms]}, id: {type: string}}}` in every row:

| parent schema | null (before) | null (after) | valid object |
|---|---|---|---|
| `{allOf: [B], nullable: true}` | **FAIL** | pass | pass |
| `{type: object, allOf: [B], nullable: true}` | **FAIL** | pass | pass |
| `{anyOf: [B], nullable: true}` | **FAIL** | pass | pass |
| `{oneOf: [B], nullable: true}` | **FAIL** | pass | pass |
| `{allOf: [B]}` (not nullable) | FAIL | FAIL | pass |
| `{allOf: [B + nullable: true]}` (branch nullable) | pass | pass | pass |
| `{type: object, nullable: true, …}` (no composition) | pass | pass | pass |

## The fix

`AllOfValidator`, `AnyOfValidator`, `OneOfValidator` and `OneOfValidatorWithContext` short-circuit when the schema *carrying* the keyword is nullable, mirroring `TypeValidator`. For `anyOf`/`oneOf` this means the keyword is satisfied — not that a branch matched — so `oneOf` still enforces exactly-one for non-null data. The rule lives in one place, `SchemaValueNormalizer::isNullableSchema()`, which `TypeValidator` now routes through too.

Deliberate boundaries:

- Gated on `nullableAsType`. With `disableNullableAsType()`, `null` against a nullable composition still fails, matching today's behaviour for plain nullable schemas.
- Branch-level `nullable` and OAS 3.1 `type: ['object', 'null']` are unchanged, inside and outside compositions. A `null` member of a `type` union is ordinary JSON Schema and keeps composing — `{type: ['object','null'], allOf: [B]}` still rejects `null`, because `allOf` is an in-place applicator. Only `nullable: true`, which OAS 3.0.3 defines as "allows sending a `null` value for the defined schema", waives branches. Both directions are pinned by tests.
- Discriminator handling is unaffected; a discriminated `oneOf` with a nullable parent accepts `null` and still discriminates non-null data.

## Audit of the other `SchemaValueNormalizer::normalize()` callers

The defect is specific to *in-place* applicators — a sub-schema applied to the same data instance the parent's `nullable` covers.

- **No defect** — `PropertiesValidator`, `ItemsValidator`, `PrefixItemsValidator` and the `*WithContext` variants normalize a *child* value against that child's own schema. The sub-schema consulted is the schema being applied to that value, so branch-level nullability is the correct question there; the parent's `nullable` describes the parent value, not its children.
- **No defect** — `DependentSchemasValidator` returns early for non-array data, so `null` never reaches its `normalize()` call.
- **No defect** — `NotValidator` already accepts `null` under a nullable parent: a `not` branch that fails to normalize counts as not-matched, which satisfies `not`.
- **Fixed** — `IfThenElseValidator` did share the defect. `{if: …, else: …, nullable: true}` leaked an `InvalidDataTypeException` (not even a `ValidationException`) out of the `else` branch for `null`.

The compiler path needs no change: `UnsupportedKeywordDetector` rejects `allOf`/`anyOf`/`oneOf`, so compiled validators never reach this code.

## Tests

Written before the fix and confirmed failing for the documented reason:

- `tests/Unit/Validator/SchemaValidator/NullableCompositionTest.php` — the full acceptance matrix via `validateSchema()`, the `nullableAsType: false` rows, OAS 3.1 type unions in both directions, `oneOf` overlap rejection, discriminated `oneOf`, and the other in-place applicators.
- `tests/Functional/Response/NullableCompositionTest.php` — the issue's exact JSON:API-shaped document through the PSR-7 `validateResponse()` path and its nested `properties` chain, which is where real documents hit this.
- Validator-level cases added to `AllOfValidatorTest`, `AnyOfValidatorTest`, `OneOfValidatorTest` and `IfThenElseValidatorTest` to cover the no-context path.

`make tests` (7177 tests), `make psalm` (no errors), `make cs-fix` and `make rector` are clean. Scoped `make infection` over the touched files: covered MSI 90% (threshold 78) — the one escaped mutant in new code is an equivalent `?->` → `->` rewrite inside a `??`.

## Out of scope

`ValidationException::getErrors()` returning an empty list for composition failures (the issue's secondary observation) is untouched and still reproduces for genuinely-failing `allOf` branches — `AbstractCompositionalValidator::validateBranch()` drops branch errors that are not `AbstractValidationError` instances. Worth its own issue.