### PR TITLE
fix: Merge Path Item level parameters into the operation before request validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Path Item level `parameters` are now enforced during request validation.
+  `PathItem.parameters` were parsed into the schema model but never reached
+  `RequestValidator`, so `required` and `schema` constraints on parameters
+  hoisted to the path item — the place the specification encourages for
+  parameters shared by every operation under a path — were silently ignored
+  for every location (`path`, `query`, `header`, `cookie`). Path item
+  parameters are now merged into the operation's parameter set when the
+  operation is resolved, with an operation level parameter overriding the
+  path level one on matching `name` + `in`. The same merge is applied to
+  webhooks and callbacks, which are Path Item objects as well. (#61)
+
 ## [0.7.0]
 
 Preparation for the 1.0.0 stable release. This section tracks work that

--- a/src/Validator/Callback/CallbackValidator.php
+++ b/src/Validator/Callback/CallbackValidator.php
@@ -14,6 +14,7 @@ use Duyler\OpenApi\Validator\Exception\RefResolutionException;
 use Duyler\OpenApi\Validator\Exception\UnresolvableCallbackPathException;
 use Duyler\OpenApi\Validator\PregExecutor;
 use Duyler\OpenApi\Validator\Request\PathRegexCache;
+use Duyler\OpenApi\Validator\Internal\PathItemParameterMerger;
 use Duyler\OpenApi\Validator\Request\RequestValidatorInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
@@ -177,7 +178,7 @@ final readonly class CallbackValidator
             $operation = $resolved->getOperation($method);
 
             if (null !== $operation) {
-                return [$operation, $pathTemplate];
+                return [PathItemParameterMerger::merge($resolved, $operation), $pathTemplate];
             }
         }
 

--- a/src/Validator/Internal/PathItemParameterMerger.php
+++ b/src/Validator/Internal/PathItemParameterMerger.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duyler\OpenApi\Validator\Internal;
+
+use Duyler\OpenApi\Schema\Model\Operation;
+use Duyler\OpenApi\Schema\Model\Parameter;
+use Duyler\OpenApi\Schema\Model\Parameters;
+use Duyler\OpenApi\Schema\Model\PathItem;
+
+/** @internal */
+final readonly class PathItemParameterMerger
+{
+    public static function merge(PathItem $pathItem, Operation $operation): Operation
+    {
+        $pathLevel = $pathItem->parameters?->parameters ?? [];
+
+        if ([] === $pathLevel) {
+            return $operation;
+        }
+
+        $operationLevel = $operation->parameters?->parameters ?? [];
+
+        $overridden = [];
+        foreach ($operationLevel as $param) {
+            $key = self::identity($param);
+            if (null !== $key) {
+                $overridden[$key] = true;
+            }
+        }
+
+        $merged = $operationLevel;
+        foreach ($pathLevel as $param) {
+            $key = self::identity($param);
+            if (null !== $key && isset($overridden[$key])) {
+                continue;
+            }
+
+            $merged[] = $param;
+        }
+
+        if ($merged === $operationLevel) {
+            return $operation;
+        }
+
+        return new Operation(
+            tags: $operation->tags,
+            summary: $operation->summary,
+            description: $operation->description,
+            externalDocs: $operation->externalDocs,
+            operationId: $operation->operationId,
+            parameters: new Parameters($merged),
+            requestBody: $operation->requestBody,
+            responses: $operation->responses,
+            callbacks: $operation->callbacks,
+            deprecated: $operation->deprecated,
+            security: $operation->security,
+            servers: $operation->servers,
+        );
+    }
+
+    private static function identity(Parameter|string $parameter): ?string
+    {
+        if (false === $parameter instanceof Parameter) {
+            return null;
+        }
+
+        if (null === $parameter->name || null === $parameter->in) {
+            return null;
+        }
+
+        return $parameter->in . "\0" . $parameter->name;
+    }
+}

--- a/src/Validator/PathFinder.php
+++ b/src/Validator/PathFinder.php
@@ -9,6 +9,7 @@ use Duyler\OpenApi\Schema\Model\PathItem;
 use Duyler\OpenApi\Schema\OpenApiDocument;
 use Duyler\OpenApi\Validator\Exception\OperationNotFoundException;
 use Duyler\OpenApi\Validator\Internal\CandidatePrioritizer;
+use Duyler\OpenApi\Validator\Internal\PathItemParameterMerger;
 use Duyler\OpenApi\Validator\Internal\TrieBuilder;
 use Duyler\OpenApi\Validator\Internal\TrieLookup;
 use Duyler\OpenApi\Validator\Request\PathParser;
@@ -124,7 +125,7 @@ final readonly class PathFinder
                 path: $pathPattern,
                 method: $method,
                 operationId: $schemaOperation->operationId,
-                schemaOperation: $schemaOperation,
+                schemaOperation: PathItemParameterMerger::merge($pathItem, $schemaOperation),
             );
         }
 
@@ -135,7 +136,7 @@ final readonly class PathFinder
                         path: $pathPattern,
                         method: $method,
                         operationId: $additionalOp->operationId,
-                        schemaOperation: $additionalOp,
+                        schemaOperation: PathItemParameterMerger::merge($pathItem, $additionalOp),
                     );
                 }
             }

--- a/src/Validator/Webhook/WebhookValidator.php
+++ b/src/Validator/Webhook/WebhookValidator.php
@@ -7,6 +7,7 @@ namespace Duyler\OpenApi\Validator\Webhook;
 use Duyler\OpenApi\Schema\Model\Operation;
 use Duyler\OpenApi\Schema\Model\PathItem;
 use Duyler\OpenApi\Schema\OpenApiDocument;
+use Duyler\OpenApi\Validator\Internal\PathItemParameterMerger;
 use Duyler\OpenApi\Validator\Request\RequestValidatorInterface;
 use Duyler\OpenApi\Validator\Webhook\Exception\UnknownWebhookException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -58,6 +59,6 @@ final readonly class WebhookValidator
             );
         }
 
-        return $operation;
+        return PathItemParameterMerger::merge($webhook, $operation);
     }
 }

--- a/tests/Functional/Request/PathItemParametersTest.php
+++ b/tests/Functional/Request/PathItemParametersTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duyler\OpenApi\Test\Functional\Request;
+
+use Duyler\OpenApi\Builder\OpenApiValidatorBuilder;
+use Duyler\OpenApi\Validator\Exception\EnumError;
+use Duyler\OpenApi\Validator\Exception\InvalidFormatException;
+use Duyler\OpenApi\Validator\Exception\MissingParameterException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PathItemParametersTest extends TestCase
+{
+    private const string WIDGETS_YAML = <<<YAML
+openapi: 3.0.0
+info:
+  title: Path Level Parameters API
+  version: 1.0.0
+paths:
+  /widgets/{widgetId}:
+    parameters:
+      - name: widgetId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: mustHave
+        in: query
+        required: true
+        schema:
+          type: string
+          enum: [alpha, beta]
+    get:
+      responses:
+        '200':
+          description: ok
+    delete:
+      responses:
+        '204':
+          description: ok
+YAML;
+
+    private const string OVERRIDE_YAML = <<<YAML
+openapi: 3.0.0
+info:
+  title: Override API
+  version: 1.0.0
+paths:
+  /widgets:
+    parameters:
+      - name: status
+        in: query
+        required: true
+        schema:
+          type: string
+          enum: [alpha, beta]
+    get:
+      parameters:
+        - name: status
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [gamma]
+      responses:
+        '200':
+          description: ok
+YAML;
+    private Psr17Factory $psrFactory;
+
+    protected function setUp(): void
+    {
+        $this->psrFactory = new Psr17Factory();
+    }
+
+    #[Test]
+    public function path_item_level_required_query_parameter_is_enforced(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::WIDGETS_YAML)
+            ->build();
+
+        $request = $this->psrFactory->createServerRequest(
+            'GET',
+            'http://localhost/widgets/2b3e0c4a-59f4-4c4f-9a0a-1e0d9c7f0b11',
+        );
+
+        $this->expectException(MissingParameterException::class);
+
+        $validator->validateRequest($request);
+    }
+
+    #[Test]
+    public function path_item_level_query_parameter_schema_is_enforced(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::WIDGETS_YAML)
+            ->build();
+
+        $request = $this->psrFactory->createServerRequest(
+            'GET',
+            'http://localhost/widgets/2b3e0c4a-59f4-4c4f-9a0a-1e0d9c7f0b11?mustHave=gamma',
+        );
+
+        $this->expectException(EnumError::class);
+
+        $validator->validateRequest($request);
+    }
+
+    #[Test]
+    public function path_item_level_path_parameter_schema_is_enforced(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::WIDGETS_YAML)
+            ->build();
+
+        $request = $this->psrFactory->createServerRequest(
+            'GET',
+            'http://localhost/widgets/not-a-uuid?mustHave=alpha',
+        );
+
+        $this->expectException(InvalidFormatException::class);
+
+        $validator->validateRequest($request);
+    }
+
+    #[Test]
+    public function request_satisfying_path_item_level_parameters_is_accepted(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::WIDGETS_YAML)
+            ->build();
+
+        $request = $this->psrFactory->createServerRequest(
+            'GET',
+            'http://localhost/widgets/2b3e0c4a-59f4-4c4f-9a0a-1e0d9c7f0b11?mustHave=alpha',
+        );
+
+        $operation = $validator->validateRequest($request);
+
+        $this->assertSame('/widgets/{widgetId}', $operation->path);
+    }
+
+    #[Test]
+    public function path_item_level_parameters_apply_to_every_operation_under_the_path(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::WIDGETS_YAML)
+            ->build();
+
+        $request = $this->psrFactory->createServerRequest(
+            'DELETE',
+            'http://localhost/widgets/2b3e0c4a-59f4-4c4f-9a0a-1e0d9c7f0b11',
+        );
+
+        $this->expectException(MissingParameterException::class);
+
+        $validator->validateRequest($request);
+    }
+
+    #[Test]
+    public function operation_level_parameter_overrides_path_item_level_parameter_with_same_name_and_in(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::OVERRIDE_YAML)
+            ->build();
+
+        $request = $this->psrFactory->createServerRequest(
+            'GET',
+            'http://localhost/widgets?status=gamma',
+        );
+
+        $operation = $validator->validateRequest($request);
+
+        $this->assertSame('/widgets', $operation->path);
+    }
+
+    #[Test]
+    public function overridden_path_item_level_parameter_no_longer_applies(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::OVERRIDE_YAML)
+            ->build();
+
+        $request = $this->psrFactory->createServerRequest(
+            'GET',
+            'http://localhost/widgets?status=alpha',
+        );
+
+        $this->expectException(EnumError::class);
+
+        $validator->validateRequest($request);
+    }
+
+    #[Test]
+    public function operation_level_parameters_are_still_enforced_alongside_path_item_level_ones(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::OVERRIDE_YAML)
+            ->build();
+
+        $request = $this->psrFactory->createServerRequest('GET', 'http://localhost/widgets');
+
+        $this->expectException(MissingParameterException::class);
+
+        $validator->validateRequest($request);
+    }
+}

--- a/tests/Integration/Validator/PathItemParametersMergeTest.php
+++ b/tests/Integration/Validator/PathItemParametersMergeTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duyler\OpenApi\Test\Integration\Validator;
+
+use Duyler\OpenApi\Builder\OpenApiValidatorBuilder;
+use Duyler\OpenApi\Validator\Exception\EnumError;
+use Duyler\OpenApi\Validator\Exception\MissingParameterException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/** @internal */
+final class PathItemParametersMergeTest extends TestCase
+{
+    private const string WEBHOOK_YAML = <<<'YAML'
+openapi: 3.1.0
+info:
+  title: Webhook Path Level Parameters API
+  version: 1.0.0
+webhooks:
+  payment.completed:
+    parameters:
+      - name: X-Signature
+        in: header
+        required: true
+        schema:
+          type: string
+    post:
+      responses:
+        '200':
+          description: OK
+YAML;
+
+    private const string CALLBACK_YAML = <<<'YAML'
+openapi: 3.1.0
+info:
+  title: Callback Path Level Parameters API
+  version: 1.0.0
+components:
+  callbacks:
+    invoiceCallback:
+      invoiceCallback:
+        '/webhook/invoice':
+          parameters:
+            - name: mode
+              in: query
+              required: true
+              schema:
+                type: string
+                enum: [live, test]
+          post:
+            responses:
+              '200':
+                description: OK
+YAML;
+
+    private Psr17Factory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new Psr17Factory();
+    }
+
+    #[Test]
+    public function webhook_path_item_level_parameter_is_enforced(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::WEBHOOK_YAML)
+            ->build();
+
+        $request = $this->factory->createServerRequest('POST', 'http://localhost/webhook');
+
+        $this->expectException(MissingParameterException::class);
+
+        $validator->validateWebhook($request, 'payment.completed');
+    }
+
+    #[Test]
+    public function webhook_satisfying_path_item_level_parameter_is_accepted(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::WEBHOOK_YAML)
+            ->build();
+
+        $request = $this->factory->createServerRequest('POST', 'http://localhost/webhook')
+            ->withHeader('X-Signature', 'sha256=abc');
+
+        $operation = $validator->validateWebhook($request, 'payment.completed');
+
+        $this->assertSame('payment.completed', $operation->path);
+    }
+
+    #[Test]
+    public function callback_path_item_level_parameter_schema_is_enforced(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::CALLBACK_YAML)
+            ->build();
+
+        $request = $this->factory->createServerRequest(
+            'POST',
+            'http://localhost/webhook/invoice?mode=staging',
+        );
+
+        $this->expectException(EnumError::class);
+
+        $validator->validateCallback($request, 'invoiceCallback');
+    }
+
+    #[Test]
+    public function callback_satisfying_path_item_level_parameter_is_accepted(): void
+    {
+        $validator = OpenApiValidatorBuilder::create()
+            ->fromYamlString(self::CALLBACK_YAML)
+            ->build();
+
+        $request = $this->factory->createServerRequest(
+            'POST',
+            'http://localhost/webhook/invoice?mode=live',
+        );
+
+        $operation = $validator->validateCallback($request, 'invoiceCallback');
+
+        $this->assertSame('POST', $operation->method);
+    }
+}


### PR DESCRIPTION
Fixes #61.

## The bug

`PathItem.parameters` are parsed into the schema model and then dropped before validation. `RequestValidator::validate()` receives only the `Operation` and builds `$parameterSchemas` from `$operation->parameters` alone, so parameters declared on the Path Item — which the specification defines as applying to every operation under that path — are never enforced. `required: true` passes when omitted, and `schema` constraints (`enum`, `format`, …) are never checked, for every location (`path`, `query`, `header`, `cookie`). Nothing errors, so a spec author gets no signal that a whole class of parameters is unvalidated.

## The fix

`Validator\Internal\PathItemParameterMerger` merges the path item's parameters into the operation's set at the point where the operation is resolved from the path item, so `$operation->parameters` is already complete by the time it reaches request validation — `RequestValidator` is unchanged. Per the specification, an operation level parameter overrides the path level one on matching `name` + `in`; the merger returns the operation unchanged when the path item declares no parameters, so specs that do not use the feature pay nothing.

Applied at all three sites that resolve an `Operation` from a `PathItem`:

- `PathFinder::getOperation()` — request validation, including `additionalOperations`
- `WebhookValidator::extractOperation()` — webhooks are Path Item objects and had the identical defect
- `CallbackValidator::extractOperation()` — likewise, after `$ref` resolution

`ResponseValidationHandler` also resolves an operation from a path item, but response validation does not read parameters, so it is left alone.

## Tests

Written test-first; each was watched failing against the unfixed source before the implementation landed.

`tests/Functional/Request/PathItemParametersTest.php` (8 tests) — the three violations from the issue (required query parameter omitted, query `enum`, path `format: uuid`), a valid request still accepted, path item parameters applying to a second operation on the same path, and the override rule in both directions.

`tests/Integration/Validator/PathItemParametersMergeTest.php` (4 tests) — the same enforcement for webhooks (`in: header`) and callbacks (`in: query`).

Two checks on the tests themselves:

- Stashing `PathFinder.php` and re-running turns 4 of the 8 functional tests red, so they do target the reported defect rather than existing behaviour.
- Disabling only the `name` + `in` override skip makes `operation_level_parameter_overrides_path_item_level_parameter_with_same_name_and_in` fail — the path level `enum: [alpha, beta]` rejects a request the operation level `enum: [gamma]` allows — so that test genuinely pins the override rule and not just the merge.

The reproduction script from the issue now prints `REJECTED` for all three cases.

## Verification

- `vendor/bin/phpunit` — 7143 tests, 14734 assertions, OK. The 2 deprecation notices are pre-existing and unrelated to this change.
- `vendor/bin/psalm` — no errors.
- `vendor/bin/php-cs-fixer fix --dry-run` — 0 of 880 files to fix.
- `vendor/bin/rector process --dry-run` — clean.

CHANGELOG entry added under a new `## [Unreleased]` / `### Fixed` heading.