### PR TITLE
fix: Merge $ref sibling `nullable` with OR so 3.0 nullable targets keep null (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- OpenAPI 3.0 `nullable: true` is no longer discarded when a schema is
+  reached through `$ref`. `ScalarSiblingMerger::merge()` combined the `$ref`
+  stub's `nullable` flag with the resolved target's using a logical AND, and
+  because `Schema::$nullable` defaults to `false` a bare `{$ref: ...}` stub
+  always evaluated `false && true` — erasing the target's nullability, so a
+  legitimate `null` was rejected by `TypeValidator`. The flag now merges with
+  OR: per OpenAPI 3.0 a `nullable` sibling next to `$ref` can only widen the
+  target, and there is no spelling for "narrow this to non-nullable" (#64).
+
 ## [0.7.0]
 
 Preparation for the 1.0.0 stable release. This section tracks work that

--- a/src/Schema/Model/Internal/ScalarSiblingMerger.php
+++ b/src/Schema/Model/Internal/ScalarSiblingMerger.php
@@ -38,7 +38,7 @@ final readonly class ScalarSiblingMerger implements SiblingMergerStrategy
         return [
             'format' => $this->mergeFormat($resolved->format, $sibling->format),
             'type' => $this->mergeType($resolved->type, $sibling->type),
-            'nullable' => $sibling->nullable && $resolved->nullable,
+            'nullable' => $sibling->nullable || $resolved->nullable,
             'const' => $sibling->hasConst ? $sibling->const : $resolved->const,
             'hasConst' => $sibling->hasConst || $resolved->hasConst,
             'multipleOf' => $this->mergeNullableIdentical($resolved->multipleOf, $sibling->multipleOf),

--- a/tests/Integration/NullableRefSiblingTest.php
+++ b/tests/Integration/NullableRefSiblingTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Duyler\OpenApi\Test\Integration;
+
+use Duyler\OpenApi\Builder\OpenApiValidatorBuilder;
+use Duyler\OpenApi\Builder\OpenApiValidatorInterface;
+use Duyler\OpenApi\Validator\Exception\ValidationException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NullableRefSiblingTest extends TestCase
+{
+    private const string SPEC = <<<'YAML'
+        openapi: 3.0.0
+        info:
+          title: Nullable Ref API
+          version: 1.0.0
+        paths: {}
+        components:
+          schemas:
+            NullableString:
+              type: string
+              nullable: true
+            UnionNullString:
+              type: [string, 'null']
+            NonNullableString:
+              type: string
+
+            InlineProp:
+              type: object
+              properties:
+                p:
+                  type: string
+                  nullable: true
+            RefProp:
+              type: object
+              properties:
+                p:
+                  $ref: '#/components/schemas/NullableString'
+            RefPropRestatingNullable:
+              type: object
+              properties:
+                p:
+                  $ref: '#/components/schemas/NullableString'
+                  nullable: true
+            RefPropTypeUnion:
+              type: object
+              properties:
+                p:
+                  $ref: '#/components/schemas/UnionNullString'
+            RefPropNullableSibling:
+              type: object
+              properties:
+                p:
+                  $ref: '#/components/schemas/NonNullableString'
+                  nullable: true
+            RefPropNonNullable:
+              type: object
+              properties:
+                p:
+                  $ref: '#/components/schemas/NonNullableString'
+        YAML;
+
+    #[Test]
+    public function inline_nullable_property_accepts_null(): void
+    {
+        $this->validator()->validateSchema(['p' => null], '#/components/schemas/InlineProp');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function bare_ref_to_nullable_schema_accepts_null(): void
+    {
+        $this->validator()->validateSchema(['p' => null], '#/components/schemas/RefProp');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function ref_restating_nullable_accepts_null(): void
+    {
+        $this->validator()->validateSchema(['p' => null], '#/components/schemas/RefPropRestatingNullable');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function ref_to_type_union_with_null_accepts_null(): void
+    {
+        $this->validator()->validateSchema(['p' => null], '#/components/schemas/RefPropTypeUnion');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function nullable_sibling_widens_non_nullable_target(): void
+    {
+        $this->validator()->validateSchema(['p' => null], '#/components/schemas/RefPropNullableSibling');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function bare_ref_to_non_nullable_schema_still_rejects_null(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->validator()->validateSchema(['p' => null], '#/components/schemas/RefPropNonNullable');
+    }
+
+    #[Test]
+    public function bare_ref_to_nullable_schema_still_rejects_wrong_type(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->validator()->validateSchema(['p' => 42], '#/components/schemas/RefProp');
+    }
+
+    private function validator(): OpenApiValidatorInterface
+    {
+        return OpenApiValidatorBuilder::create()->fromYamlString(self::SPEC)->build();
+    }
+}

--- a/tests/Integration/PostRefactorBehavioralSnapshotTest.php
+++ b/tests/Integration/PostRefactorBehavioralSnapshotTest.php
@@ -355,23 +355,25 @@ final class PostRefactorBehavioralSnapshotTest extends TestCase
     }
 
     // ---------------------------------------------------------------------
-    // Zone 2: SchemaSiblingMerger — AND-merge semantics
+    // Zone 2: SchemaSiblingMerger — merge semantics
     // ---------------------------------------------------------------------
 
     #[Test]
-    public function sibling_merger_nullable_AND_semantics_sibling_false_blocks_null(): void
+    public function sibling_merger_nullable_widening_semantics_sibling_false_keeps_null(): void
     {
         $resolved = new Schema(type: 'string', nullable: true);
         $sibling = new Schema(nullable: false);
 
         $merged = new SchemaSiblingMerger()->merge($resolved, $sibling);
 
-        // AND semantics: both must allow null for the merge to allow null.
-        self::assertFalse($merged->nullable);
+        // Widening semantics: a `nullable` sibling next to `$ref` can only add
+        // null to the target. `nullable: false` is indistinguishable from an
+        // omitted flag, so it never removes the target's nullability.
+        self::assertTrue($merged->nullable);
     }
 
     #[Test]
-    public function sibling_merger_nullable_AND_semantics_both_true_allows_null(): void
+    public function sibling_merger_nullable_widening_semantics_both_true_allows_null(): void
     {
         $resolved = new Schema(type: 'string', nullable: true);
         $sibling = new Schema(nullable: true);

--- a/tests/Unit/Schema/Model/Internal/ScalarSiblingMergerTest.php
+++ b/tests/Unit/Schema/Model/Internal/ScalarSiblingMergerTest.php
@@ -34,18 +34,29 @@ final class ScalarSiblingMergerTest extends TestCase
     }
 
     #[Test]
-    public function merge_nullable_uses_and_semantics_sibling_false_blocks_null(): void
+    public function merge_nullable_keeps_resolved_nullable_when_sibling_omits_it(): void
     {
         $resolved = new Schema(type: 'string', nullable: true);
         $sibling = new Schema(nullable: false);
 
         $overrides = new ScalarSiblingMerger()->merge(new SiblingMergeContext($resolved, $sibling));
 
-        self::assertFalse($overrides['nullable']);
+        self::assertTrue($overrides['nullable']);
     }
 
     #[Test]
-    public function merge_nullable_and_semantics_both_true_allows_null(): void
+    public function merge_nullable_sibling_widens_non_nullable_resolved(): void
+    {
+        $resolved = new Schema(type: 'string', nullable: false);
+        $sibling = new Schema(nullable: true);
+
+        $overrides = new ScalarSiblingMerger()->merge(new SiblingMergeContext($resolved, $sibling));
+
+        self::assertTrue($overrides['nullable']);
+    }
+
+    #[Test]
+    public function merge_nullable_both_true_allows_null(): void
     {
         $resolved = new Schema(type: 'string', nullable: true);
         $sibling = new Schema(nullable: true);
@@ -53,6 +64,17 @@ final class ScalarSiblingMergerTest extends TestCase
         $overrides = new ScalarSiblingMerger()->merge(new SiblingMergeContext($resolved, $sibling));
 
         self::assertTrue($overrides['nullable']);
+    }
+
+    #[Test]
+    public function merge_nullable_stays_false_when_neither_side_is_nullable(): void
+    {
+        $resolved = new Schema(type: 'string', nullable: false);
+        $sibling = new Schema(nullable: false);
+
+        $overrides = new ScalarSiblingMerger()->merge(new SiblingMergeContext($resolved, $sibling));
+
+        self::assertFalse($overrides['nullable']);
     }
 
     #[Test]

--- a/tests/Unit/Schema/Model/SchemaSiblingMergerTest.php
+++ b/tests/Unit/Schema/Model/SchemaSiblingMergerTest.php
@@ -108,29 +108,29 @@ final class SchemaSiblingMergerTest extends TestCase
     }
 
     #[Test]
-    public function merge_nullable_and_when_resolved_rejects_null(): void
+    public function merge_nullable_widens_when_only_sibling_allows_null(): void
     {
         $resolved = new Schema(type: 'string', nullable: false);
         $sibling = new Schema(nullable: true);
 
         $merged = new SchemaSiblingMerger()->merge($resolved, $sibling);
 
-        self::assertFalse($merged->nullable);
+        self::assertTrue($merged->nullable);
     }
 
     #[Test]
-    public function merge_nullable_and_when_sibling_rejects_null(): void
+    public function merge_nullable_keeps_resolved_when_sibling_omits_nullable(): void
     {
         $resolved = new Schema(type: 'string', nullable: true);
         $sibling = new Schema(nullable: false);
 
         $merged = new SchemaSiblingMerger()->merge($resolved, $sibling);
 
-        self::assertFalse($merged->nullable);
+        self::assertTrue($merged->nullable);
     }
 
     #[Test]
-    public function merge_nullable_and_when_both_allow_null(): void
+    public function merge_nullable_when_both_allow_null(): void
     {
         $resolved = new Schema(type: 'string', nullable: true);
         $sibling = new Schema(nullable: true);


### PR DESCRIPTION
Fixes #64.

## The bug

`ScalarSiblingMerger::merge()` combined the `$ref` stub's `nullable` flag with the resolved target's using a logical **AND**:

```php
'nullable' => $sibling->nullable && $resolved->nullable,
```

`Schema::$nullable` defaults to `false` and a bare `{$ref: ...}` node never sets it, so every plain `$ref` evaluated `false && true` and discarded the target's `nullable: true`. The resolved schema kept its `type: string` but lost its nullability, and `TypeValidator` then rejected a legitimate `null` — making a very common OpenAPI 3.0 arrangement unusable:

```yaml
NullableString:
  type: string
  nullable: true
Thing:
  type: object
  properties:
    p:
      $ref: '#/components/schemas/NullableString'   # null was rejected
```

## The fix

One line — the flag now merges with **OR**. Per OpenAPI 3.0 a `nullable` sibling next to `$ref` can only *widen* the target; there is no way to spell "narrow this to non-nullable", so `nullable: false` is indistinguishable from an omitted flag and must never remove the target's nullability. This also makes `nullable` consistent with how the same class merges every other scalar (`mergeFormat`, `mergeNullableIdentical`: "sibling wins if set, otherwise the resolved value").

`ScalarSiblingMerger` is the only merge implementation — `Schema::withSibling()` and `BoundSiblingMerger` both route through it, and no compiled path carries its own copy — so this is the single fix point.

## A second manifestation, not in the issue report

The issue notes that restating `nullable: true` at the referring site works around the bug. That only holds when the *target* is also nullable. A `nullable: true` sibling against a **non-nullable** target evaluated `true && false` and was likewise erased, so the sibling could not widen anything. Both cases are covered by the new tests.

## Heads-up: this reverses a documented decision

The AND was deliberate — the 0.7.0 changelog records it as `SchemaSiblingMerger::merge()` aligning `nullable` with "§8.2.3 ALL OF semantics (SPEC-02B)". That reading is defensible for a real `allOf`, but it cannot survive a `false` default: with no way to distinguish "unset" from "explicitly false", AND makes the dominant case — a bare `$ref` — unusable.

Three existing tests asserted the AND behaviour and are updated to the widening semantics (`ScalarSiblingMergerTest`, `SchemaSiblingMergerTest`, `PostRefactorBehavioralSnapshotTest`). The sibling-false cases now document *why* `nullable: false` cannot narrow, rather than simply flipping the expectation.

I also considered making `Schema::$nullable` tri-state (`?bool`) so "omitted" and "explicitly false" become distinguishable, which would let AND work honestly. I rejected it: it touches the 56-parameter constructor and every validator call site, and buys nothing, since OpenAPI 3.0 has no narrowing semantics for a `nullable` sibling. Happy to take that route instead if you would rather keep intersection semantics.

## Tests

Written test-first; both new tests were watched failing against the AND before the fix landed.

- `tests/Integration/NullableRefSiblingTest.php` (new) — the issue's four cases (inline nullable, bare `$ref`, `$ref` restating `nullable`, 3.1 `type: [string, 'null']` union) plus three guards: a nullable sibling widening a non-nullable target, a bare `$ref` to a non-nullable target still rejecting `null`, and a bare `$ref` to a nullable target still rejecting a wrong-typed value.
- `tests/Unit/Schema/Model/Internal/ScalarSiblingMergerTest.php` — merge-level coverage for all four `nullable` combinations, including that neither side nullable still yields `false`.

## Verification

- `vendor/bin/phpunit` — 7140 tests, 14726 assertions, all pass. (The 2 deprecation notices are pre-existing and from unrelated tests.)
- `vendor/bin/psalm` — no errors.
- `vendor/bin/php-cs-fixer fix --dry-run` — 0 of 878 files need fixing.
- `vendor/bin/rector --dry-run` — clean.
- The issue's verbatim reproduction script prints `PASS` for all four schemas; stashing only the one-line change reproduces `RefProp   Schema validation failed`.

No inline comments were added to `src/` per the current convention; the rationale lives in the changelog entry and the tests. Glad to add a `// §N exemption:`-style note at the merge site if you would prefer the reasoning to sit next to the code.
